### PR TITLE
add query start time to the interpret method

### DIFF
--- a/src/main/java/com/teragrep/pth_15/DPLExecutor.java
+++ b/src/main/java/com/teragrep/pth_15/DPLExecutor.java
@@ -49,6 +49,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
@@ -60,7 +61,8 @@ public interface DPLExecutor {
             String queryId,
             String noteId,
             String paragraphId,
-            String lines
+            String lines,
+            ZonedDateTime startTime
     ) throws TimeoutException;
 
     public abstract void stop() throws TimeoutException;

--- a/src/test/java/com/teragrep/pth_15/DPLExecutorTestImpl.java
+++ b/src/test/java/com/teragrep/pth_15/DPLExecutorTestImpl.java
@@ -50,6 +50,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
+import java.time.ZonedDateTime;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
@@ -65,7 +66,8 @@ public final class DPLExecutorTestImpl implements DPLExecutor {
             String queryId,
             String noteId,
             String paragraphId,
-            String lines
+            String lines,
+            ZonedDateTime startTime
     ) throws TimeoutException {
         throw new UnsupportedOperationException("Not supported.");
     }


### PR DESCRIPTION
## Description

Add a ZonedDateTime query start time to interpret() method. Query start time is planned to be required when constructing the DPL context in pth_10